### PR TITLE
Local URL and custom route

### DIFF
--- a/lib/Textpress/Textpress.php
+++ b/lib/Textpress/Textpress.php
@@ -418,6 +418,9 @@ class Textpress
                 $args = func_get_args();
                 $layout = isset($value['layout']) ? $value['layout'] : true;
 
+                // This will store a custom function if defined into the route
+                $custom = isset($value['custom']) ? $value['custom'] : false;
+
                 if(!$layout){
                     $self->enableLayout = false;
                 }
@@ -426,7 +429,7 @@ class Textpress
                 }
 
                 $self->slim->view()->appendGlobalData(array("route" => $key));
-                $template = $value['template'];
+                $template = isset($value['template']) ? $value['template'] : false;
 
                 //set view data for article  and archives routes
                 switch ($key) {
@@ -447,6 +450,12 @@ class Textpress
                     case 'category' :
                     case 'tag'      :
                         $self->filterArticles($key,$args[0]);
+                        break;
+
+                    // If key is not matched, check if a custom function is declared
+                    default:
+                        if ($custom && is_callable($custom))
+                            call_user_func($custom, $self, $key, $value);
                         break;
                 }
 


### PR DESCRIPTION
This pull request introduces two new features :

1/ Make local URL accessible into globals variable

It was usefull for me to get the local URL of the article into layouts. With the URL, I can populate OpenGraph attributes which need the complete URL of an article.

With this code, the URL is now accessible into `$globals`, and can be read by layouts.

2/ Add the possibility to set custom function for a given route

I need to be able to create custom function to do custom things outside Textpress.

Now it is possible by defining the `custom` key into a route set into config.php.
