### PR TITLE
Ability to add more than two articles per day when the preferences are the default ones

### DIFF
--- a/src/shameerc/Textpress/Textpress.php
+++ b/src/shameerc/Textpress/Textpress.php
@@ -264,7 +264,9 @@ class Textpress
         foreach($articles as $article) {
             $date = new \DateTime($article->getDate());
             $timestamp = $date->getTimestamp();
-            $timestamp = array_key_exists($timestamp, $results) ? $timestamp + 1 : $timestamp;
+            while (array_key_exists($timestamp, $results)) {
+                $timestamp += 1;
+            }
             $results[$timestamp] = $article;
         }
         krsort($results);


### PR DESCRIPTION
By default the date format is "d M, Y" so the time information is not contained, this means that if you try to create more than two articles on the same day, the first will be in "timestamp" date, the second "timestamp + 1 "after which the next ones will overwrite each other and will not be displayed in the feed. the modification allows to overcome this limit